### PR TITLE
Add proxy config parsing

### DIFF
--- a/config
+++ b/config
@@ -14,5 +14,9 @@ path /echo EchoHandler {}
 
 path /status StatusHandler {}
 
+path /ucla ProxyHandler {
+	url www.ucla.edu;
+}
+
 # Default response handler if no handlers match.
 default NotFoundHandler {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,11 @@ void getServerOptions(NginxConfig config, http::server::server_options *server_o
       else if (statement.at(2) == "StatusHandler") {
         server_options_pointer->status_handler = statement.at(1);
       }
+      // Proxy
+      else if (statement.at(2) == "ProxyHandler") {
+        server_options_pointer->proxy_handlers[statement.at(1)] = config_line->child_block_;
+      }
+
       server_options_pointer->all_handlers.push_back(std::make_pair(statement.at(2), statement.at(1)));
     }
 
@@ -102,7 +107,11 @@ void printParsedConfig(http::server::server_options *server_options_pointer) {
   for (auto it = server_options_pointer->static_handlers.begin(); it != server_options_pointer->static_handlers.end(); ++it) {
     std::cout << "Static Handler "<< it->first << "\n";
   }
-  
+
+  for (auto it = server_options_pointer->proxy_handlers.begin(); it != server_options_pointer->proxy_handlers.end(); ++it) {
+    std::cout << "Proxy Handler "<< it->first << "\n";
+  }
+
   std::cout << "Default Handler " << server_options_pointer->default_handler << "\n";
   std::cout << "Status Handler " << server_options_pointer->status_handler << "\n";
   std::cout << "*******************************" << "\n";

--- a/src/request_handler_proxy.cpp
+++ b/src/request_handler_proxy.cpp
@@ -1,0 +1,28 @@
+//
+// request_handler_proxy.cpp
+// ~~~~~~~~~~~~~~~~~~~
+//
+
+#include "request_handler_proxy.hpp"
+#include <string>
+#include <boost/lexical_cast.hpp>
+#include "response.hpp"
+#include "request.hpp"
+#include "request_handler.hpp"
+
+namespace http {
+namespace server {
+
+RequestHandler::Status ProxyHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
+	return RequestHandler::OK;
+}
+
+RequestHandler::Status ProxyHandler::HandleRequest(const Request& request, Response* response) {
+
+	return RequestHandler::OK;
+}
+
+REGISTER_REQUEST_HANDLER(ProxyHandler);
+
+} // namespace server
+} // namespace http

--- a/src/request_handler_proxy.hpp
+++ b/src/request_handler_proxy.hpp
@@ -1,0 +1,25 @@
+//
+// request_handler_proxy.hpp
+// ~~~~~~~~~~~~~~~~~~~
+//
+
+#ifndef HTTP_REQUEST_HANDLER_PROXY_HPP
+#define HTTP_REQUEST_HANDLER_PROXY_HPP
+
+#include "request_handler.hpp"
+
+namespace http {
+namespace server {
+
+// Handler for echo requests.
+class ProxyHandler : public http::server::RequestHandler {
+public:
+  Status Init(const std::string& uri_prefix, const NginxConfig& config) override;
+
+  Status HandleRequest(const Request& request, Response* response) override;
+};
+
+} // namespace server
+} // namespace http
+
+#endif // HTTP_REQUEST_HANDLER_PROXY_HPP

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -51,6 +51,16 @@ Server::Server(const std::string& address, const server_options* server_options)
     handlers_[uri_prefix] = handler_;
   }
 
+  // Initialize proxy handlers.
+  for (auto it = server_options_->proxy_handlers.begin(); it != server_options_->proxy_handlers.end(); ++it) {
+    std::string uri_prefix = it->first;
+    NginxConfig* config = it->second;
+    // Create handler.
+    handler_ = RequestHandler::CreateByName("ProxyHandler");
+    handler_->Init(uri_prefix, *config);
+    handlers_[uri_prefix] = handler_;
+  }
+
   // Initialize status handler.
   std::string uri_prefix = server_options_->status_handler;
   handler_ = RequestHandler::CreateByName("StatusHandler");

--- a/src/server_options.hpp
+++ b/src/server_options.hpp
@@ -1,6 +1,6 @@
 //
 // server_options.hpp
-// 
+//
 
 #ifndef SERVER_OPTIONS_HPP
 #define SERVER_OPTIONS_HPP
@@ -22,6 +22,9 @@ struct server_options {
   // Map of static handlers (key is the path, value is the
   // NginxConfig child block containing the root info)
   std::map<std::string, NginxConfig*> static_handlers;
+
+  // Same as above for proxy handlers
+  std::map<std::string, NginxConfig*> proxy_handlers;
 
   // Status Handler
   std::string status_handler;

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -5,10 +5,10 @@ make
 
 # Start the server
 echo "Running an integration test on the server"
-echo "server { listen 8080;
-path /echo EchoHandler;
-path /static1 StaticFileHandler { root www; }
-path /static2 StaticFileHandler { root pics; } }" >> test_config
+echo "port 8080;
+path /echo EchoHandler {}
+path /static1 StaticHandler { root www; }
+path /static2 StaticHandler { root pics; }" > test_config
 ./webserver test_config &>/dev/null &
 
 # Send a request to the server using curl
@@ -20,7 +20,7 @@ curl -s localhost:8080/static2/giphy.gif > test_output_static2_gif
 curl -s localhost:8080/static2/mario.jpeg > test_output_static2_jpeg
 
 # Verify the response from the server works as expected
-diff expected_echo_output test_output_echo > diff_echo_output
+diff test/expected_echo_output test_output_echo > diff_echo_output
 EXIT_STATUS+=$?
 diff www/index.html test_output_static1 > diff_static1_output
 EXIT_STATUS+=$?
@@ -51,7 +51,7 @@ fi
 echo "Cleaning up and shutting down"
 pkill webserver
 make clean
-rm test_config
+test_config
 rm test_output_echo
 rm test_output_static1
 rm test_output_static2_jpg

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -51,7 +51,7 @@ fi
 echo "Cleaning up and shutting down"
 pkill webserver
 make clean
-test_config
+rm test_config
 rm test_output_echo
 rm test_output_static1
 rm test_output_static2_jpg


### PR DESCRIPTION
1. added simple syntax in config to for parsing
2. added proxy_handlers map to server_options structure, and populate it when parsing config file
3. added a skeleton of the proxy request handler, and created by name in server.cpp. currently doesn't actually do anything yet, will be implemented later.
4. some small integration test fixes, we have different http and curl versions but I'll ignore those